### PR TITLE
add nix dependency zlib

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,6 @@
 resolver: nightly-2019-10-15
 packages:
 - .
+nix:
+  packages:
+    - zlib


### PR DESCRIPTION
In order to build dprox on nixos, we need to explicitly specify zlib in stack.yaml.